### PR TITLE
Fix compilation on SBCL 1.4.10+

### DIFF
--- a/asm/x86-32,64-insts.lisp
+++ b/asm/x86-32,64-insts.lisp
@@ -131,7 +131,7 @@
        ;; emit 32-bit, signed relative offset for where
        (emit-dword-displacement-backpatch segment where)
        ;; nowhere to jump: simply jump to the next instruction
-       (sb-vm::emit-skip segment 4 0))))
+       (sb-assem::%emit-skip segment 4 0))))
 
 
 #-#.(stmx.asm::compile-if-instruction-defined 'xend)


### PR DESCRIPTION
* Lots of symbols were removed/renamed/moved in the 1.4.10 release
* stmx depends on internal interfaces of sb-* packages leading to
  unfortunate brittleness like this.

Not sure exactly how to deal with depending on internal sb-* symbols, as stmx is obviously implementing some very cool functionality and implementing it as close to the hardware as possible such that it really, genuinely does benefit from using these internal interfaces.

After a quick discussion in #sbcl on freenode, it seems there isn't _much_ consensus on how to actually deal with this. As an example, a user mentioned in #sbcl that there are many quicklisp packages that are depending on internal sb-* interfaces. 