### PR TITLE
Tighten up tlog-func-vector type

### DIFF
--- a/main/classes.lisp
+++ b/main/classes.lisp
@@ -81,7 +81,7 @@
 
 ;;;; ** implementation class: tlog
 
-(deftype tlog-func-vector () '(and vector (not simple-array)))
+(deftype tlog-func-vector () '(and (vector function *) (not simple-array)))
 
 (defstruct tlog
   "a transaction log (tlog) is a record of the reads and writes


### PR DESCRIPTION
In principle, one could remove (the function) from the aref use of this array now, but it doesn't hurt for those implementations where type tracking isn't good.