### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ in the sources - remember `(describe 'some-symbol)` at REPL.
              (value2 :type string  :initarg :value2 :initform ""))))
 
         (transactional
-          (defstruct bar ()
+          (defstruct bar
             (value1 0  :type integer)
             (value2 "" :type string)))
 


### PR DESCRIPTION
Fix a small typo in the sample code provided in the README.